### PR TITLE
ci: bump actions/create-github-app-token v2 -> v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Silences the Node 20 deprecation warning on the Semantic Release job.

`v3.0.0` switched the action's runtime to Node 24. Breaking changes (custom proxy handling removed, self-hosted runner version requirement) do not affect this workflow — GitHub-hosted runners have no proxy and we use `ubuntu-latest`.

GitHub deadline: forced Node 24 default on **2026-06-02** (~6 days), Node 20 removed on **2026-09-16**.

## Test plan

- [x] One-line action version bump — no code or behavior change
- [ ] After merge: next Release run has no deprecation warning on the `Generate GitHub App token` step