### PR TITLE
fix(deps): bump shell-quote to 1.8.4 to patch critical CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9297,9 +9297,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bumps shell-quote 1.8.3 → 1.8.4 to resolve GHSA-w7jw-789q-3m8p (`quote()` does not escape newlines in object `.op` values).

shell-quote is a dev-only transitive dependency (via npm-run-all2). It is never shipped to consumers — the published tarball is `build/` only and shell-quote is not a runtime dependency — so no released npm/jsr version is affected. This clears the alert and keeps the dev toolchain clean.

Leaves the esbuild advisory GHSA-gv7w-rqvm-qjhr as-is on purpose: it is a Deno-only code path (`lib/deno/mod.ts`) with no impact on npm/Node installs (Node already verifies binary integrity), and forcing esbuild 0.28.1 breaks vite's `^0.27` pin.

Lockfile-only change, within existing ranges. Build, test and lint pass.