### PR TITLE
fix(deps): bump shell-quote to 1.8.4 to patch critical CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9297,9 +9297,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Promotes `development` to `main` for a stable release.

Carries the shell-quote 1.8.4 bump (GHSA-w7jw-789q-3m8p). shell-quote is a dev-only transitive dependency (via npm-run-all2) and is not part of the published tarball, so this is dependency hygiene / alert clearing rather than a consumer-facing security fix.